### PR TITLE
Update keyboard IDs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Build package (live)

--- a/make_uconsole-sleep_package.sh
+++ b/make_uconsole-sleep_package.sh
@@ -79,7 +79,7 @@ cat << 'EOF' > uconsole-sleep/usr/local/src/uconsole-sleep/find_internal_kb.py
 import os
 
 
-def find_internal_kb(ids=["feed:0000", "1eaf:0003"]):
+def find_internal_kb(ids=["1eaf:0024", "feed:0000", "1eaf:0003"]):
     usb_device_path = ""
 
     for device in os.listdir("/sys/bus/usb/devices/"):


### PR DESCRIPTION
On my uconsole with CM4 and Debian Trixie the sleep_power_control failed with this error resulting in not limiting the CPU freqency:

    Oct 10 15:55:33 clockworkpi sleep_power_control[816]:   File "sleep_power_control.py", line 62, in <module>
    Oct 10 15:55:33 clockworkpi sleep_power_control[816]: Exception: there's no matched kb

This PR adds a new keyboard id and the sleep power control seems to work again.
